### PR TITLE
Prevent an undefined bug by setting using the default for thickness

### DIFF
--- a/uw/index.js
+++ b/uw/index.js
@@ -980,7 +980,7 @@ Costume._polygon = function(props) {
         if (-y > maxY) maxY = -y
     }
 
-    var margin = props.outline ? props.thickness : 0
+    var margin = props.outline ? (props.thickness || 2) : 0
     minX -= round(margin)
     minY -= round(margin)
     maxX += round(margin)


### PR DESCRIPTION
When you have set an outline but no thickness, we were tripping over this line as it tries to use the thickness but this is not set, causing the round to throw NaN. In the docs, the default is 2, so I've used this if there is no thickness, not sure if this should be set in a more clever way.