### PR TITLE
Add `world.KeyPressed`

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -133,6 +133,14 @@ world.background = &#39;white&#39;
 <li><p><strong><code>world.background</code></strong></p>
 <p>The background colour of the world. Uses HTML/CSS colours, such as <code>red</code> or <code>#007de0</code>.</p>
 </li>
+<li><p><strong><code>world.keyPressed</code></strong></p>
+<p>An object with all of the keys that are currently held, based on their <a href="https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values">key value</a>.</p>
+<p>Check if keys are currently being pressed with code like:</p>
+<pre><code class="lang-js">if (world.keyPressed[&#39;w&#39;] || world.keyPressed[&#39;ArrowUp&#39;]) {
+    // Do something…
+}
+</code></pre>
+</li>
 </ul>
 <p>World has the following methods:</p>
 <ul>

--- a/docs/sheets/reference.md
+++ b/docs/sheets/reference.md
@@ -131,6 +131,17 @@ It has the following attributes:
 
     The background colour of the world. Uses HTML/CSS colours, such as `red` or `#007de0`.
 
+  * **`world.keyPressed`**
+
+    An object with all of the keys that are currently held, based on their [key value](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values).
+
+    Check if keys are currently being pressed with code like:
+
+    ```js
+    if (world.keyPressed['w'] || world.keyPressed['ArrowUp']) {
+        // Do something…
+    }
+    ```
 
 World has the following methods:
 

--- a/uw/index.js
+++ b/uw/index.js
@@ -173,6 +173,9 @@ var World = function(props) {
     window.addEventListener('resize', () => { this._needsResize = true })
     this._bindPointer()
 
+    this.keyPressed = Object.create(null)
+    this._bindKeys()
+
     //const de = document.documentElement
     Object.assign(this, {
         background: '#fff',
@@ -436,6 +439,26 @@ World.prototype.pointerUp = function(e) {
         }
         this.emitTap(finger)
     }
+}
+
+World.prototype._bindKeys = function(e) {
+    document.addEventListener('keydown', this.keyDown.bind(this))
+    document.addEventListener('keyup', this.keyUp.bind(this))
+
+    // Make sure all keys are released when the tab loses focus.
+    window.addEventListener('blur', e => {
+        for (const key in this.keyPressed) {
+            delete this.keyPressed[key]
+        }
+    })
+}
+
+World.prototype.keyDown = function(e) {
+  this.keyPressed[e.key] = true
+}
+
+World.prototype.keyUp = function(e) {
+  delete this.keyPressed[e.key]
 }
 
 


### PR DESCRIPTION
you-win was originally intended for mobile games, so emphasises touch (or mouse) input (as well as accelerometer input, until browsers made that hard/impossible to access).

However people do often want to use keyboard input, and while you _can_ use vanilla JS for this — e.g. `document.addEventListener('keydown', e => { … })` — this doesn't result in smooth movement for games like pong, since events are fired based on the device's key delay/repeat settings.

So this PR adds support to `you-win` for checking whether a key is pressed. We listen to keydown/keyup events, and track pressed keys in an object — which means you can check on each frame (i.e. inside `forever()`) whether a key is pressed, which results in much smoother movement.

I've used [key values](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values) rather than keycode values like `39` since [keyCodes are deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). Key values appear to be [widely supported](https://caniuse.com/keyboardevent-key) since around 2017 (there's even partial support in IE11?!).

```js
paddle.forever(() => {
  if (world.keyPressed['w'] || world.keyPressed['ArrowUp']) {
    paddle.posY += 10
  }
  if (world.keyPressed['s'] || world.keyPressed['ArrowDown']) {
    paddle.posY -= 10
  }
})
```

---

FWIW, I am still in favour of encouraging/steering people toward touch input, so the results are playable on a phone.

One nice complement to `world.keyPressed` might be to add a new `Button` class. This could be based on `Rect`, as a convenient way to get a little box on screen with an outline and label text. We might have them default to transparent (partially see-through); and give you a convenient way to hide them on touch-first devices like phones.

<img width="250" src="https://github.com/user-attachments/assets/4e0d74ee-029e-4d32-a7af-2bc26536f3c9" />


```
var phone = new Phone

var buttonUp = new Button
buttonUp.label = "↑"
buttonUp.posX = 10
buttonUp.posY = 120
buttonUp.opacity = phone.hasMultiTouch ? 0.5 : 0

var buttonDown = new Button
buttonDown.label = "↓"
buttonDown.posX = 10
buttonDown.posY = 50
buttonDown.opacity = phone.hasMultiTouch ? 0.5 : 0

paddle.forever(() => {
  if (world.keyPressed['w'] || buttonUp.isPressed) {
    paddle.posY += 10
  }
  if (world.keyPressed['s'] || buttonDown.isPressed) {
    paddle.posY -= 10
  }
})
```
Note:
- `phone.hasMultiTouch` already exists — the `Phone` class was a wrapper around the accelerometer APIs.
- I don't think we currently have anything like `isPressed` or `isTouched` but this seems easy enough to add.